### PR TITLE
Changes NonText background to match the default background

### DIFF
--- a/colors/monokai_pro.vim
+++ b/colors/monokai_pro.vim
@@ -48,7 +48,7 @@ hi Function ctermfg=150 ctermbg=NONE cterm=NONE guifg=#a9dc76 guibg=NONE gui=NON
 hi Identifier ctermfg=116 ctermbg=NONE cterm=NONE guifg=#78dce8 guibg=NONE gui=italic
 hi Keyword ctermfg=204 ctermbg=NONE cterm=NONE guifg=#ff6188 guibg=NONE gui=NONE
 hi Label ctermfg=204 ctermbg=NONE cterm=NONE guifg=#ff6188 guibg=NONE gui=NONE
-hi NonText ctermfg=240 ctermbg=59 cterm=NONE guifg=#5b595c guibg=#373538 gui=NONE
+hi NonText ctermfg=240 ctermbg=59 cterm=NONE guifg=#5b595c guibg=#2d2a2e gui=NONE
 hi Number ctermfg=147 ctermbg=NONE cterm=NONE guifg=#ab9df2 guibg=NONE gui=NONE
 hi Special ctermfg=147 ctermbg=NONE cterm=NONE guifg=#ab9df2 guibg=NONE gui=NONE
 hi Operator ctermfg=204 ctermbg=NONE cterm=NONE guifg=#ff6188 guibg=NONE gui=NONE


### PR DESCRIPTION
The NonText background is too eye catching, this PR suggest to use the same color as the default background, making the NonText elements less visible.