### PR TITLE
Fix xterm color value of `Normal`

### DIFF
--- a/colors/monokai_pro.vim
+++ b/colors/monokai_pro.vim
@@ -30,7 +30,7 @@ hi IncSearch ctermfg=16 ctermbg=221 cterm=NONE guifg=#2d2a2e guibg=#ffd866 gui=N
 hi Search ctermfg=NONE ctermbg=NONE cterm=underline guifg=NONE guibg=NONE gui=underline
 hi Directory ctermfg=209 ctermbg=NONE cterm=NONE guifg=#fc9867 guibg=NONE gui=NONE
 hi Folded ctermfg=189 ctermbg=60 cterm=NONE guifg=#d7d7ff guibg=#5f5f87 gui=NONE
-hi Normal ctermfg=231 ctermbg=16 cterm=NONE guifg=#fcfcfa guibg=#2d2a2e gui=NONE
+hi Normal ctermfg=231 ctermbg=236 cterm=NONE guifg=#fcfcfa guibg=#2d2a2e gui=NONE
 hi Boolean ctermfg=147 ctermbg=NONE cterm=NONE guifg=#ab9df2 guibg=NONE gui=NONE
 hi Character ctermfg=147 ctermbg=NONE cterm=NONE guifg=#ab9df2 guibg=NONE gui=NONE
 hi Comment ctermfg=59 ctermbg=NONE cterm=NONE guifg=#727072 guibg=NONE gui=italic


### PR DESCRIPTION
The current xterm background color value (`16`) of `Normal` seems to be a bit off on Vim without GUI color enabled.
Based on the current corresponding GUI background color (#2d2a2e), I updated xterm color value to `236`, which will be translated to #303030 in the pre-define 256-color palette.